### PR TITLE
feat: migrate all GithubExplorer files from validation layer

### DIFF
--- a/src/presentation/protocols/validation.ts
+++ b/src/presentation/protocols/validation.ts
@@ -1,0 +1,3 @@
+export interface Validation {
+  validate: (value: string) => null | Error
+}

--- a/src/validation/RequiredFieldValidator.ts
+++ b/src/validation/RequiredFieldValidator.ts
@@ -1,0 +1,11 @@
+import { Validation } from '../presentation/protocols/validation'
+import { RequiredFieldError } from './errors/RequiredFieldError'
+
+export class RequiredFieldValidator implements Validation {
+  validate = (value: string): null | Error => {
+    if (!value || /^\s*$/.test(value)) {
+      return new RequiredFieldError()
+    }
+    return null
+  }
+}

--- a/src/validation/errors/RequiredFieldError.ts
+++ b/src/validation/errors/RequiredFieldError.ts
@@ -1,0 +1,6 @@
+export class RequiredFieldError extends Error {
+  constructor() {
+    super('Required Field')
+    this.name = 'RequiredFieldError'
+  }
+}


### PR DESCRIPTION
For this migration, you need to understand that the validation layer depends on the presentation layer protocol to create its validators. So it is required to migrate the protocol in this step.

